### PR TITLE
File::Find 1.41 uses forward slashes for all file paths

### DIFF
--- a/lib/File/Find/Rule.pm
+++ b/lib/File/Find/Rule.pm
@@ -599,6 +599,8 @@ sub in {
     for my $path (@_) {
         # $topdir is used for relative and maxdepth
         $topdir = $path;
+        $topdir =~ s{\\}{/}g
+          if $^O eq q{MSWin32} and $File::Find::VERSION ge 1.41;
         # slice off the trailing slash if there is one (the
         # maxdepth/mindepth code is fussy)
         $topdir =~ s{/?$}{}

--- a/t/File-Find-Rule.t
+++ b/t/File-Find-Rule.t
@@ -2,7 +2,7 @@
 #       $Id$
 
 use strict;
-use Test::More tests => 46;
+use Test::More tests => 48;
 use File::Spec;
 
 if (eval { require Test::Differences; 1 }) {
@@ -332,3 +332,21 @@ like( $@, qr/^couldn't bootstrap File::Find::Rule::Test::Elusive/,
 eval { $class->import(':Test::ATeam') };
 is ($@, "",  "if you can find them, maybe you can hire the A-Team" );
 can_ok( $class, 'ba' );
+
+
+#  File::Find 1.41
+{
+    #  need to normalise paths for comparison
+    my @got =
+        map {File::Spec->canonpath ($_)}
+        map {File::Spec->rel2abs($_)}
+        find->file()->name('*.t')->maxdepth(1)->in('./testdir');
+
+    my @expected =
+        map {File::Spec->canonpath ($_)}
+        map {File::Spec->rel2abs($_)}
+        glob 'testdir/*.t';
+
+    is scalar @got, 2, "Got correct number of files";
+    is_deeply(\@got, \@expected, 'Found expected files');
+}


### PR DESCRIPTION
$topdir needs to be updated to match.

Updates RT 147252
https://rt.cpan.org/Public/Bug/Display.html?id=147252