### PR TITLE
Fix for CVE-2011-10007: Use 3 arg open in `grep()`

### DIFF
--- a/lib/File/Find/Rule.pm
+++ b/lib/File/Find/Rule.pm
@@ -420,7 +420,7 @@ sub grep {
 
     $self->exec( sub {
         local *FILE;
-        open FILE, $_ or return;
+        open FILE, '<', $_ or return;
         local ($_, $.);
         while (<FILE>) {
             for my $p (@pattern) {


### PR DESCRIPTION
This addresses CVE-2011-10007, a code execution vulnerability, by using the 3 argument form for `open()`

https://lists.security.metacpan.org/cve-announce/msg/30183067/


PoC:
```
$ mkdir /tmp/poc; echo > "/tmp/poc/|id"
$ perl -MFile::Find::Rule \
     -E 'File::Find::Rule->grep("foo")->in("/tmp/poc")'
uid=1000(user) gid=1000(user) groups=1000(user),100(users)
```

Initial bug report of the vulnerability (that didn't consider code execution impact): https://rt.cpan.org/Public/Bug/Display.html?id=64504
